### PR TITLE
Improve Gradle plugin implementation

### DIFF
--- a/gradle-plugin/karakum-gradle-plugin/src/main/kotlin/io/github/sgrishchenko/karakum/gradle/plugin/KarakumPlugin.kt
+++ b/gradle-plugin/karakum-gradle-plugin/src/main/kotlin/io/github/sgrishchenko/karakum/gradle/plugin/KarakumPlugin.kt
@@ -1,8 +1,8 @@
 package io.github.sgrishchenko.karakum.gradle.plugin
 
 import io.github.sgrishchenko.karakum.gradle.plugin.tasks.KarakumConfig
-import io.github.sgrishchenko.karakum.gradle.plugin.tasks.KarakumCopy
 import io.github.sgrishchenko.karakum.gradle.plugin.tasks.KarakumGenerate
+import io.github.sgrishchenko.karakum.gradle.plugin.tasks.KarakumSync
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.FileTree
@@ -20,11 +20,11 @@ class KarakumPlugin : Plugin<Project> {
 
                 extensionSource.convention(
                     listOf(
-                    rootProject.layout.projectDirectory.dir("buildSrc/karakum"),
-                    layout.projectDirectory.dir("karakum"),
-                )
-                    .map { it.asFileTree }
-                    .reduce(FileTree::plus)
+                        rootProject.layout.projectDirectory.dir("buildSrc/karakum"),
+                        layout.projectDirectory.dir("karakum"),
+                    )
+                        .map { it.asFileTree }
+                        .reduce(FileTree::plus)
                 )
             }
 
@@ -33,11 +33,14 @@ class KarakumPlugin : Plugin<Project> {
                 description = "Prepares the Karakum configuration using the Gradle project layout."
 
                 configFile.convention(karakum.configFile)
+                cwd.convention(project.kotlinJsCompilation.npmProject.dir)
+                buildSrc.convention(project.rootProject.layout.projectDirectory.dir("buildSrc"))
+                nodeModules.convention(project.rootProject.layout.buildDirectory.dir("js/node_modules"))
 
                 destinationFile.convention(layout.buildDirectory.file("karakum/$KARAKUM_CONFIG_FILE"))
             }
 
-            val copyKarakumExtensions by tasks.registering(KarakumCopy::class) {
+            val syncKarakumExtensions by tasks.registering(KarakumSync::class) {
                 group = KARAKUM_GRADLE_PLUGIN_GROUP
                 description = "Copies the Karakum extensions to the npm project."
 
@@ -52,7 +55,7 @@ class KarakumPlugin : Plugin<Project> {
                 description = "Generates the Kotlin external declarations using Karakum."
 
                 configFile.convention(configureKarakum.flatMap { it.destinationFile })
-                extensionDirectory.convention(copyKarakumExtensions.flatMap { it.destinationDirectory })
+                extensionDirectory.convention(syncKarakumExtensions.flatMap { it.destinationDirectory })
             }
         }
     }

--- a/gradle-plugin/karakum-gradle-plugin/src/main/kotlin/io/github/sgrishchenko/karakum/gradle/plugin/tasks/KarakumGenerate.kt
+++ b/gradle-plugin/karakum-gradle-plugin/src/main/kotlin/io/github/sgrishchenko/karakum/gradle/plugin/tasks/KarakumGenerate.kt
@@ -7,11 +7,15 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.*
+import org.gradle.process.ExecOperations
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrCompilation
 import org.jetbrains.kotlin.gradle.targets.js.npm.RequiresNpmDependencies
 import org.jetbrains.kotlin.gradle.targets.js.npm.npmProject
+import javax.inject.Inject
 
 abstract class KarakumGenerate : DefaultTask(), RequiresNpmDependencies {
+    @get:Inject
+    abstract val exec: ExecOperations
 
     @get:InputFile
     abstract val configFile: RegularFileProperty
@@ -30,7 +34,7 @@ abstract class KarakumGenerate : DefaultTask(), RequiresNpmDependencies {
 
     @TaskAction
     fun generate() {
-        project.exec {
+        exec.exec {
             compilation.npmProject.useTool(
                 this,
                 "karakum/build/cli.js",

--- a/gradle-plugin/karakum-gradle-plugin/src/main/kotlin/io/github/sgrishchenko/karakum/gradle/plugin/tasks/KarakumSync.kt
+++ b/gradle-plugin/karakum-gradle-plugin/src/main/kotlin/io/github/sgrishchenko/karakum/gradle/plugin/tasks/KarakumSync.kt
@@ -2,14 +2,18 @@ package io.github.sgrishchenko.karakum.gradle.plugin.tasks
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.file.FileTree
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import javax.inject.Inject
 
+abstract class KarakumSync : DefaultTask() {
+    @get:Inject
+    abstract val fs: FileSystemOperations
 
-abstract class KarakumCopy : DefaultTask() {
     @get:InputFiles
     abstract val extensionSource: Property<FileTree>
 
@@ -17,8 +21,8 @@ abstract class KarakumCopy : DefaultTask() {
     abstract val destinationDirectory: DirectoryProperty
 
     @TaskAction
-    fun copy() {
-        project.copy {
+    fun sync() {
+        fs.sync {
             from(extensionSource)
             into(destinationDirectory)
         }

--- a/gradle-plugin/karakum-gradle-plugin/src/test/kotlin/io/github/sgrishchenko/karakum/gradle/plugin/KarakumPluginTest.kt
+++ b/gradle-plugin/karakum-gradle-plugin/src/test/kotlin/io/github/sgrishchenko/karakum/gradle/plugin/KarakumPluginTest.kt
@@ -13,7 +13,7 @@ class KarakumPluginTest {
         project.plugins.apply("io.github.sgrishchenko.karakum")
 
         // Verify tasks
-        assertNotNull(project.tasks.findByName("copyKarakumPlugins"))
+        assertNotNull(project.tasks.findByName("syncKarakumExtensions"))
         assertNotNull(project.tasks.findByName("configureKarakum"))
         assertNotNull(project.tasks.findByName("generateKarakumExternals"))
     }


### PR DESCRIPTION
This PR makes various improvements to the Gradle plugin.
Main changes are:
- it makes the `KarakumCopy` task a `KarakumSync` task
- it properly declares the inputs of the `KarakumConfig` task
- it uses injectable service instead of using `project` at execution time which is deprecated and also makes the plugin unusable with configuration cache
