### PR TITLE
Disallow additional properties in the schema where not explicitly intended

### DIFF
--- a/schema/generate.ts
+++ b/schema/generate.ts
@@ -14,10 +14,10 @@ const conflictResolutionStrategySchemaFileName = "schema/conflict-resolution-str
 const configurationSchemaFileName = "schema/karakum-schema.json"
 
 await Promise.all([
-    exec(`typescript-json-schema --titles --include src/configuration/configuration.ts --out ${granularitySchemaFileName} tsconfig.json Granularity`),
-    exec(`typescript-json-schema --titles --include src/configuration/configuration.ts --out ${namespaceStrategySchemaFileName} tsconfig.json NamespaceStrategy`),
-    exec(`typescript-json-schema --titles --include src/configuration/configuration.ts --out ${conflictResolutionStrategySchemaFileName} tsconfig.json ConflictResolutionStrategy`),
-    exec(`typescript-json-schema --titles --include src/configuration/configuration.ts --out ${configurationSchemaFileName} tsconfig.json SchemaConfiguration`),
+    exec(`typescript-json-schema --titles --noExtraProps --include src/configuration/configuration.ts --out ${granularitySchemaFileName} tsconfig.json Granularity`),
+    exec(`typescript-json-schema --titles --noExtraProps --include src/configuration/configuration.ts --out ${namespaceStrategySchemaFileName} tsconfig.json NamespaceStrategy`),
+    exec(`typescript-json-schema --titles --noExtraProps --include src/configuration/configuration.ts --out ${conflictResolutionStrategySchemaFileName} tsconfig.json ConflictResolutionStrategy`),
+    exec(`typescript-json-schema --titles --noExtraProps --include src/configuration/configuration.ts --out ${configurationSchemaFileName} tsconfig.json SchemaConfiguration`),
 ])
 
 const granularitySchema: Schema = JSON.parse(await fs.readFile(granularitySchemaFileName, "utf8"))

--- a/schema/karakum-schema.json
+++ b/schema/karakum-schema.json
@@ -26,6 +26,7 @@
             "type": "string"
         }
     },
+    "additionalProperties": false,
     "properties": {
         "annotations": {
             "anyOf": [
@@ -43,6 +44,7 @@
         },
         "compilerOptions": {
             "$ref": "https://json.schemastore.org/tsconfig#/definitions/compilerOptionsDefinition/properties/compilerOptions",
+            "additionalProperties": false,
             "title": "compilerOptions",
             "type": "object"
         },

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -75,6 +75,7 @@ export interface SchemaConfiguration {
     /**
      * @TJS-type object
      * @$ref https://json.schemastore.org/tsconfig#/definitions/compilerOptionsDefinition/properties/compilerOptions
+     * @additionalProperties false
      * */
     compilerOptions?: Record<string, unknown>
 


### PR DESCRIPTION
It is good practice to disallow additional properties where not explicitly intended.
There were two spots where additional properties were allowed implicitly.
This PR fixes that.
