### PR TITLE
Disambiguate names for String unions instead of omitting them

### DIFF
--- a/src/converter/plugins/StringUnionTypePlugin.ts
+++ b/src/converter/plugins/StringUnionTypePlugin.ts
@@ -69,9 +69,10 @@ export function convertStringUnionType(
             checkCoverageService?.cover(literal)
 
             const value = literal.text
-            const key = value === ""
+            const valueAsIdentifier = identifier(value)
+            const key = (value === "") || (valueAsIdentifier === "")
                 ? "`_`"
-                : identifier(value)
+                : valueAsIdentifier
             return [key, value] as const
         })
 

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -32,14 +32,22 @@ export function escapeIdentifier(string: string) {
         return `\`${string}\``
     }
 
+    if (/^_+$/.test(string)) {
+        return `\`${string}\``
+    }
+
     return string
+}
+
+export function notEscapedIdentifier(string: string) {
+    return camelize(
+        string.replace(/\W/g, "-")
+    )
 }
 
 export function identifier(string: string) {
     return escapeIdentifier(
-        camelize(
-            string.replace(/\W/g, "-")
-        )
+        notEscapedIdentifier(string)
     )
 }
 

--- a/test/functional/base/generated/union/duplicates.kt
+++ b/test/functional/base/generated/union/duplicates.kt
@@ -11,9 +11,7 @@ sealed external interface Enc {
 companion object {
 @seskar.js.JsValue("utf8")
 val utf8: Enc
-/*
-Duplicated names were generated:
-utf8 for "utf-8"
-*/
+@seskar.js.JsValue("utf-8")
+val utf8_2: Enc
 }
 }

--- a/test/functional/base/generated/union/stringEnum.kt
+++ b/test/functional/base/generated/union/stringEnum.kt
@@ -22,14 +22,16 @@ sealed external interface Operator {
 companion object {
 @seskar.js.JsValue("")
 val `_`: Operator
-/*
-Duplicated names were generated:
-`_` for "="
-`_` for "<"
-`_` for ">"
-`_` for "<="
-`_` for ">="
-*/
+@seskar.js.JsValue("=")
+val __2: Operator
+@seskar.js.JsValue("<")
+val __3: Operator
+@seskar.js.JsValue(">")
+val __4: Operator
+@seskar.js.JsValue("<=")
+val __5: Operator
+@seskar.js.JsValue(">=")
+val __6: Operator
 }
 }
 sealed external interface SwitcherResult {

--- a/test/functional/base/generated/union/stringEnum.kt
+++ b/test/functional/base/generated/union/stringEnum.kt
@@ -17,6 +17,21 @@ val multipartFormData: FormEncType
 }
 
 external fun switcher(): SwitcherResult
+
+sealed external interface Operator {
+companion object {
+@seskar.js.JsValue("")
+val `_`: Operator
+/*
+Duplicated names were generated:
+`_` for "="
+`_` for "<"
+`_` for ">"
+`_` for "<="
+`_` for ">="
+*/
+}
+}
 sealed external interface SwitcherResult {
 companion object {
 @seskar.js.JsValue("on")

--- a/test/functional/base/lib/union/stringEnum.d.ts
+++ b/test/functional/base/lib/union/stringEnum.d.ts
@@ -1,3 +1,5 @@
 export declare type FormEncType = "application/x-www-form-urlencoded" | "multipart/form-data";
 
 export declare function switcher(): "on" | "off"
+
+export declare type Operator = "" | "=" | "<" | ">" | "<=" | ">=";


### PR DESCRIPTION
This PR is a follow-up to #20, only the top-most commit is to be reviewed.

Instead of skipping string union constants with duplicated generated identifier names
and only mentioning them in a comment, this PR makes all of them present and accessible
with disambiguated names.
